### PR TITLE
Fix linking on latest gcc

### DIFF
--- a/src/core/cpu.c
+++ b/src/core/cpu.c
@@ -27,6 +27,9 @@
 
 extern int use_verbose;
 
+/* Initialize global CPU function table*/
+cpu_op op_table[0x100];
+
 /* Initialise the CPU to safe values. */
 void cpu_init(cpu_state** state, uint8_t* mem, program_opts* opts)
 {

--- a/src/core/cpu.h
+++ b/src/core/cpu.h
@@ -136,7 +136,7 @@ typedef struct cpu_state
 
 /* Instruction function pointer table. */
 typedef void (*cpu_op)(cpu_state*);
-cpu_op op_table[0x100];
+extern cpu_op op_table[0x100];
 
 /* CPU functions. */
 void cpu_init(cpu_state**,uint8_t*,program_opts*);


### PR DESCRIPTION
When compiling with latest gcc (10 as of this PR) multiple definition errors cropped up, due to the way the opcode table was initialized. This PR fixes the errors on master, making the emulator compilable again.

Tested on Manjaro 20.1 (Linux 5.8.9-2) with:

* boing.c16
![image](https://user-images.githubusercontent.com/30842999/94275045-26ff8280-ff4f-11ea-9911-3e8544a55988.png)
* intro.c16
![image](https://user-images.githubusercontent.com/30842999/94274838-dbe56f80-ff4e-11ea-90e1-693820ad3988.png)
* BC_TestRom.c16
![image](https://user-images.githubusercontent.com/30842999/94274961-0df6d180-ff4f-11ea-8b68-78a22112b638.png)
